### PR TITLE
Added circle examples, and thurst_scaler to launch file

### DIFF
--- a/autopilot_handler/apm_handler/src/mavros_translate.cpp
+++ b/autopilot_handler/apm_handler/src/mavros_translate.cpp
@@ -142,14 +142,12 @@ void rc_callback( const mavros_msgs::RCIn::ConstPtr &msg )
 int main( int argc, char **argv )
 {
   ros::init( argc, argv, ROS_NODE_NAME );
-  
-  ros::NodeHandle nh;
+  ros::NodeHandle nh, priv_nh("~");
   
   /* Load parameters */
-  nh.param( "thrust_scaler", THRUST_SCALER, double(200.0) );
-  nh.param( "min_thrust_clip", THRUST_MIN, double(0.04) );
-  nh.param( "max_thrust_clip", THRUST_MAX, double(1.0) );
-  
+  priv_nh.param( "thrust_scaler", THRUST_SCALER, double(200.0) );
+  priv_nh.param( "min_thrust_clip", THRUST_MIN, double(0.04) );
+  priv_nh.param( "max_thrust_clip", THRUST_MAX, double(1.0) );
   
   atti_pub = nh.advertise <AttiTarget>
                             ( "/mavros/setpoint_raw/attitude", 1, true );

--- a/freyja_controller.launch
+++ b/freyja_controller.launch
@@ -1,39 +1,40 @@
 <launch>
-	<!-- vim: set ft=xml noet : -->
+  <!-- vim: set ft=xml noet : -->
 	
-	<!-- Common launch file for Freyja.
-			Supports both AscTec and Pixhawk-based vehicles. Can
-			also do velocity-only control (ignores position refs).
-			~ aj // Nimbus Lab.
-	-->
+  <!-- Common launch file for Freyja.
+  Supports both AscTec and Pixhawk-based vehicles. Can
+  also do velocity-only control (ignores position refs).
+    ~ aj // Nimbus Lab.
+  -->
 
-	<!-- allowed autopilots: "asctec" or "arducopter" -->
-	<!-- must provide vicon_topic -->
-	<arg name="autopilot" default="arducopter"/>
-	<arg name="vicon_topic"/>
-	<!-- use "device:baudrate" for apm, "device" for asctec -->
-	<arg name="comm_port" default="/dev/ttyUSB0:57600"/>
-	<arg name="total_mass" default="0.95"/>
-	<arg name="thrust_scaler" default="200.0"/>
-	<!-- true if providing your own trajectory source -->
-	<arg name="use_external_trajectory" default="false"/>
-	<arg name="use_velctrl_only" default="false"/>
-	<arg name="bias_compensation" default="false" />
-	<arg name="start_rosbag" default="false"/>
+  <!-- allowed autopilots: "asctec" or "arducopter" --> 
+  <!-- must provide vicon_topic -->
+  <arg name="autopilot" default="arducopter"/>
+  <arg name="vicon_topic"/>
+  <!-- use "device:baudrate" for apm, "device" for asctec -->
+  <arg name="comm_port" default="/dev/ttyUSB0:57600"/>
+  <arg name="total_mass" default="0.95"/>
+  <arg name="thrust_scaler" default="200.0"/>
+	
+  <!-- true if providing your own trajectory source -->
+  <arg name="use_external_trajectory" default="false"/>
+  <arg name="use_velctrl_only" default="false"/>
+  <arg name="bias_compensation" default="false" />
+  <arg name="start_rosbag" default="false"/>
 	
 	
-	<!-- state source can be: "apm", "asctec", "vicon" or "onboard_camera" -->
-	<!-- implemented filters: "median", "gauss" and "lwma" -->
+  <!-- state source can be: "apm", "asctec", "vicon" or "onboard_camera" -->
+  <!-- implemented filters: "median", "gauss" and "lwma" -->
   <node name="state_manager" pkg="state_manager" type="state_manager_node">
     <param name="state_source" type="string" value="vicon" />
     <param name="filter_type" type="string" value="median" />
     <param name="vicon_topic" type="string" value="$(arg vicon_topic)" />
   </node>
 
-	<!-- an example trajectory node for reference -->
+  <!-- an example trajectory node for reference -->
   <node name="trajectory_provider" pkg="freyja_trajectory_provider" type="trajectory_provider_node"
-				if="$(eval not use_external_trajectory)">
-	  <!-- "hover", "circle1", "circle2", "circle3" -->
+        if="$(eval not use_external_trajectory)">
+    <!-- "hover", "circle1", "circle2", "circle3" -->
     <param name="example_traj_type" type="string" value="hover"/>
   </node>
   
@@ -61,12 +62,12 @@
   
   <!-- apm/px4 needs a handler for translation, plus a mavros node -->
   <group if="$(eval autopilot=='arducopter')">
-  	<node name="apm_handler" pkg="apm_handler" type="apm_handler_node">
-		  <param name="thrust_scaler" type="double" value="$(arg thrust_scaler)" />
-	  </node>
-  	<include file="$(find freyja_configfiles)/apm_nimbus.launch">
-  		<arg name="fcu_url" value="$(arg comm_port)"/>
-  	</include>
+    <node name="apm_handler" pkg="apm_handler" type="apm_handler_node">
+      <param name="thrust_scaler" type="double" value="$(arg thrust_scaler)" />
+    </node>
+    <include file="$(find freyja_configfiles)/apm_nimbus.launch">
+      <arg name="fcu_url" value="$(arg comm_port)"/>
+    </include>
   </group>
   
   <!-- record stuff -->

--- a/freyja_controller.launch
+++ b/freyja_controller.launch
@@ -14,6 +14,7 @@
 	<!-- use "device:baudrate" for apm, "device" for asctec -->
 	<arg name="comm_port" default="/dev/ttyUSB0:57600"/>
 	<arg name="total_mass" default="0.95"/>
+	<arg name="thrust_scaler" default="200.0"/>
 	<!-- true if providing your own trajectory source -->
 	<arg name="use_external_trajectory" default="false"/>
 	<arg name="use_velctrl_only" default="false"/>
@@ -32,14 +33,14 @@
 	<!-- an example trajectory node for reference -->
   <node name="trajectory_provider" pkg="freyja_trajectory_provider" type="trajectory_provider_node"
 				if="$(eval not use_external_trajectory)">
-		<!-- "hover", "circle", "hover2" -->
-  	<param name="example_traj_type" type="string" value="hover"/>
-	</node>
+	  <!-- "hover", "circle1", "circle2", "circle3" -->
+    <param name="example_traj_type" type="string" value="hover"/>
+  </node>
   
   <!-- control node (see velctrl flag above) -->
   <node name="lqg_controller" pkg="lqg_control" type="lqg_control_node"
   			output="screen" if="$(eval not use_velctrl_only)">
-		<param name="controller_rate" value="45" type="int" />
+	  <param name="controller_rate" type="int" value="45"  />
   	<param name="total_mass" type="double" value="$(arg total_mass)"/>
   	<param name="use_stricter_gains" type="bool" value="false" />
   	<param name="estimator_rate" type="int" value="70" />
@@ -49,7 +50,7 @@
   <node name="lqr_vel_controller" pkg="lqr_control" type="lqr_vel_ctrl_node"
   			if="$(eval use_velctrl_only)">
     <param name="controller_rate" type="int" value="30" />
-    <param name="total_mass" value="$(arg total_mass)" type="double" />
+    <param name="total_mass" type="double" value="$(arg total_mass)" />
   </node>
 
   <!-- autopilot communication node -->
@@ -60,7 +61,9 @@
   
   <!-- apm/px4 needs a handler for translation, plus a mavros node -->
   <group if="$(eval autopilot=='arducopter')">
-  	<node name="apm_handler" pkg="apm_handler" type="apm_handler_node" />
+  	<node name="apm_handler" pkg="apm_handler" type="apm_handler_node">
+		  <param name="thrust_scaler" type="double" value="$(arg thrust_scaler)" />
+	  </node>
   	<include file="$(find freyja_configfiles)/apm_nimbus.launch">
   		<arg name="fcu_url" value="$(arg comm_port)"/>
   	</include>


### PR DESCRIPTION
* Changed the circle example trajectory into a function with an aggression level (`agg_level`). Added three aggression level for testing purposes.

* Added the `thrust_scaler` parameter to the launch file.

* Changed the default state to not rotate and move as far away.

Note: All changes have been tested on live drone.