### PR TITLE
Updated lqr_controL_bias to update the ctrl_mode based on the mavros control mode.

### DIFF
--- a/lqg_controller/include/lqr_control_bias.h
+++ b/lqg_controller/include/lqr_control_bias.h
@@ -24,6 +24,8 @@
 #include <freyja_msgs/ControllerDebug.h>
 #include <freyja_msgs/ReferenceState.h>
 
+#include <mavros_msgs/State.h>
+
 #include <eigen3/Eigen/Dense>
 
 #include "bias_estimator.h"
@@ -55,7 +57,8 @@ class LQRController
   
   /* Vehicle properties */
   float total_mass_;
-
+  int8_t control_mode_;
+  std::string previous_state_;
   
   /* Rotation matrices */
   Eigen::Matrix<double, 3, 3> rot_yaw_;
@@ -96,6 +99,9 @@ class LQRController
     
     ros::Subscriber reference_sub_;
     void trajectoryReferenceCallback( const TrajRef::ConstPtr & );
+
+    ros::Subscriber mavstate_sub_;
+    void mavrosStateCallback( const mavros_msgs::State::ConstPtr & );
 
     /* helper function to calculate yaw error */
     static constexpr inline double calcYawError( const double&, const double& ) __attribute__((always_inline));


### PR DESCRIPTION
This only considers a few of the more popular flight modes. It defaults to 255 when it does not recognize the flight mode.