### PR TITLE
Fix includes for ros2 humble

### DIFF
--- a/autopilot_handler/apm_handler/CMakeLists.txt
+++ b/autopilot_handler/apm_handler/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(apm_handler)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++14 -O3)
+add_compile_options(-std=c++17 -O3)
 
 SET(NO_PIXHAWK "false" CACHE BOOL "Building Pixhawk interface handler or not?")
 

--- a/autopilot_handler/apm_handler/CMakeLists.txt
+++ b/autopilot_handler/apm_handler/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(apm_handler)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++17 -O3)
+add_compile_options(-O3)
+set( CMAKE_CXX_STANDARD 17 )
 
 SET(NO_PIXHAWK "false" CACHE BOOL "Building Pixhawk interface handler or not?")
 

--- a/autopilot_handler/robomaster_handler/CMakeLists.txt
+++ b/autopilot_handler/robomaster_handler/CMakeLists.txt
@@ -3,8 +3,7 @@ project(robomaster_handler)
 
 set( ignoreMe "${NO_PIXHAWK}" )
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++17)
+set( CMAKE_CXX_STANDARD 17 )
 
 SET(NO_ROBOMASTER "false" CACHE BOOL "Building robomaster interface handler or not?")
 

--- a/autopilot_handler/robomaster_handler/CMakeLists.txt
+++ b/autopilot_handler/robomaster_handler/CMakeLists.txt
@@ -4,7 +4,7 @@ project(robomaster_handler)
 set( ignoreMe "${NO_PIXHAWK}" )
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
 
 SET(NO_ROBOMASTER "false" CACHE BOOL "Building robomaster interface handler or not?")
 

--- a/freyja_examples/examples/CMakeLists.txt
+++ b/freyja_examples/examples/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(freyja_examples)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3" )
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3" )
+set( CMAKE_CXX_STANDARD 17 )
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/freyja_examples/examples/CMakeLists.txt
+++ b/freyja_examples/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(freyja_examples)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3" )
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3" )
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/freyja_examples/flight_mode_arbitrator/CMakeLists.txt
+++ b/freyja_examples/flight_mode_arbitrator/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(flight_mode_arbitrator)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++14 -O3)
+add_compile_options(-std=c++17 -O3)
 
 SET(NO_PIXHAWK "false" CACHE BOOL "Building Pixhawk interface handler or not?")
 

--- a/freyja_examples/flight_mode_arbitrator/CMakeLists.txt
+++ b/freyja_examples/flight_mode_arbitrator/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(flight_mode_arbitrator)
 
-add_compile_options(-std=c++17 -O3)
+add_compile_options(-O3)
+set( CMAKE_CXX_STANDARD 17 )
 
 SET(NO_PIXHAWK "false" CACHE BOOL "Building Pixhawk interface handler or not?")
 

--- a/lqg_controller/CMakeLists.txt
+++ b/lqg_controller/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(lqg_control)
-add_compile_options( -std=c++14 -O3 -ffast-math -Wall )
+add_compile_options( -std=c++17 -O3 -ffast-math -Wall )
 
 set( ignoreMe "${NO_PIXHAWK}${NO_ROBOMASTER}" )
 

--- a/lqg_controller/CMakeLists.txt
+++ b/lqg_controller/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(lqg_control)
-add_compile_options( -std=c++17 -O3 -ffast-math -Wall )
+add_compile_options( -O3 -ffast-math -Wall )
+set( CMAKE_CXX_STANDARD 17 )
 
 set( ignoreMe "${NO_PIXHAWK}${NO_ROBOMASTER}" )
 

--- a/state_manager/CMakeLists.txt
+++ b/state_manager/CMakeLists.txt
@@ -6,7 +6,7 @@ set( ignoreMe "${NO_PIXHAWK}${NO_ROBOMASTER}" )
 # outdated flag, has no effect. Will be removed in the future.
 set( USINGVICON 1 )
 set( LQE_ORDER 2 )
-add_compile_options( -std=c++14 -O3 -ffast-math
+add_compile_options( -std=c++17 -O3 -ffast-math
       -DUSE_VICON_=${USINGVICON}
       -DLQE_INTEGRATOR_ORDER_=${LQE_ORDER} 
    )

--- a/state_manager/CMakeLists.txt
+++ b/state_manager/CMakeLists.txt
@@ -6,10 +6,11 @@ set( ignoreMe "${NO_PIXHAWK}${NO_ROBOMASTER}" )
 # outdated flag, has no effect. Will be removed in the future.
 set( USINGVICON 1 )
 set( LQE_ORDER 2 )
-add_compile_options( -std=c++17 -O3 -ffast-math
+add_compile_options( -O3 -ffast-math
       -DUSE_VICON_=${USINGVICON}
       -DLQE_INTEGRATOR_ORDER_=${LQE_ORDER} 
    )
+set( CMAKE_CXX_STANDARD 17 )
 
 find_package(ament_cmake REQUIRED)
 

--- a/state_manager/include/state_manager.h
+++ b/state_manager/include/state_manager.h
@@ -20,7 +20,7 @@
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/impl/utils.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/state_manager/include/state_manager.h
+++ b/state_manager/include/state_manager.h
@@ -14,7 +14,6 @@
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "geometry_msgs/msg/vector3.hpp"
-#include "sensor_msgs/msg/nav_sat_fix.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include "std_srvs/srv/set_bool.hpp"

--- a/waypoint_manager/CMakeLists.txt
+++ b/waypoint_manager/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(waypoint_manager)
-add_compile_options( -std=c++14 -O3 -ffast-math -Wall )
+add_compile_options( -std=c++17 -O3 -ffast-math -Wall )
 
 set( ignoreMe "${NO_PIXHAWK}${NO_ROBOMASTER}" )
 

--- a/waypoint_manager/CMakeLists.txt
+++ b/waypoint_manager/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(waypoint_manager)
-add_compile_options( -std=c++17 -O3 -ffast-math -Wall )
+add_compile_options( -O3 -ffast-math -Wall )
+set( CMAKE_CXX_STANDARD 17 )
 
 set( ignoreMe "${NO_PIXHAWK}${NO_ROBOMASTER}" )
 


### PR DESCRIPTION
1. `nav_sat_fix.hpp` does not seem to be used and cannot be found in humble
2. `tf2_geometry_msgs.h` is deprecated in favour of `tf2_geometry_msgs.hpp` in humble